### PR TITLE
Development

### DIFF
--- a/acmg_db/admin.py
+++ b/acmg_db/admin.py
@@ -14,6 +14,7 @@ admin.site.register(ClassificationQuestion, ClassificationQuestionAdmin)
 class ClassificationAdmin(admin.ModelAdmin):
     list_display = ('id', 'variant', 'selected_transcript_variant', 'user_first_checker', 'user_second_checker', 'status',)
     search_fields = ('id',) # cant add variant as its split into chr,pos,ref,alt in model
+    readonly_fields = ('variant', 'sample', 'selected_transcript_variant')
 admin.site.register(Classification, ClassificationAdmin)
 
 class EvidenceAdmin(admin.ModelAdmin):

--- a/env/acmg_db.yaml
+++ b/env/acmg_db.yaml
@@ -1,4 +1,8 @@
 name: acmg_db
+channels:
+- conda-forge
+- bioconda
+- defaults
 dependencies:
 - python = 3.6
 - sqlite = 3.25.3


### PR DESCRIPTION
- Make `variants`, `samples` and `sample_variants` fields in classifications admin page read only - they don't need to be edited and were causing the page to time out
- Update channels to yaml file - didn't work when setting up new conda env from scratch