### PR TITLE
Development

### DIFF
--- a/acmg_db/forms.py
+++ b/acmg_db/forms.py
@@ -1113,6 +1113,43 @@ class DownloadCNVListForm(forms.Form):
 			Field('white_list', placeholder='CNV classifications to whitelist.', title=False),
 		)
 
+class SelectAnalysisArtefacts(forms.Form):
+	"""
+	Form for downloading variant lists.
+	"""
+
+	analysis_id = forms.IntegerField()
+
+
+	def __init__(self, *args, **kwargs):
+		
+		super(SelectAnalysisArtefacts, self).__init__(*args, **kwargs)
+		self.helper = FormHelper()
+		self.helper.form_id = 'artefact_check'
+		self.helper.label_class = 'col-lg-2'
+		self.helper.field_class = 'col-lg-8'
+		self.helper.form_method = 'post'
+		self.helper.form_action = reverse('artefact_check_select')
+		self.helper.add_input(Submit('submit', 'Submit', css_class='btn-success'))
+		self.helper.form_class = 'form-horizontal'
+		self.helper.layout = Layout(
+			Field('analysis_id', placeholder='Which VariantBank Analysis to check', title=False),
+		)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 # Create the form class.
 class PhenotypeForm(ModelForm):

--- a/acmg_db/models.py
+++ b/acmg_db/models.py
@@ -78,7 +78,7 @@ class Variant(models.Model):
 
 		classifications = Classification.objects.filter(variant=self, status__in=['2', '3']).order_by('-second_check_date')
 
-		if len(classifications) >0:
+		if len(classifications) > 0:
 
 			most_recent = classifications[0]
 
@@ -299,7 +299,9 @@ class Classification(models.Model):
 	genotype = models.IntegerField(null=True, blank=True)
 	guideline_version = models.CharField(max_length=20)
 	vep_version = models.CharField(max_length=20)
-	analysis_id = models.IntegerField(null=True, blank=True)
+	analysis_id = models.IntegerField(null=True, blank=True, db_index=True)
+	artefact_checker = models.ForeignKey('auth.User', null=True, blank=True, on_delete=models.CASCADE, related_name='artefact_checker')
+	artefact_check_date = models.DateTimeField(null=True, blank=True)
 
 	def __str__(self):
 		return f'{self.id}'
@@ -334,7 +336,7 @@ class Classification(models.Model):
 
 		This displays the result of the second check analysis.
 		"""
-		if  self.second_final_class == 'False':
+		if self.second_final_class == 'False':
 			return 'False'
 		else:
 			return self.FINAL_CLASS_CHOICES[int(self.second_final_class)][1]	
@@ -505,6 +507,16 @@ class Classification(models.Model):
 		else:
 
 			return 'NA'
+
+	def get_igv_locus(self):
+		"""
+		Return the variant position for IGV
+
+		"""
+
+		variant = self.variant
+
+		return f'{variant.chromosome}:{variant.position-20}-{variant.position+20}'
 
 
 class ClassificationQuestion(models.Model):

--- a/acmg_db/templates/acmg_db/artefact_check.html
+++ b/acmg_db/templates/acmg_db/artefact_check.html
@@ -14,6 +14,10 @@
 		<td>Worklist</td>
 		<td>{{classifications.0.sample.worklist }}</td>
 	</tr>
+	<tr>
+		<td>Genome Build</td>
+		<td>{{classifications.0.sample.genome }}</td>
+	</tr>
 </table>
 
 
@@ -57,7 +61,7 @@
 
 
 
-		{% if classification.display_genuine != 'Genuine - New Classification' and classification.display_status == 'First Check' %}
+		{% if classification.display_genuine != 'Genuine - New Classification' and classification.display_status == 'First Check' and classification.user_first_checker is None %}
 
 		<td> 
 			  <select name="{{classification.pk}}" id="{{classification.pk}}">

--- a/acmg_db/templates/acmg_db/artefact_check.html
+++ b/acmg_db/templates/acmg_db/artefact_check.html
@@ -1,0 +1,94 @@
+{% extends 'acmg_db/base.html' %}
+{% load static %}
+{% block content %}
+
+
+<br>
+<h5>Artefact Check for Analysis ID {{classifications.0.analysis_id}}</h5>
+<table class = "table table-hover table-bordered col-5">
+	<tr>
+		<td style="width: 20%">Sample</td>
+		<td style="width: 20%"> {{classifications.0.sample.sample_name_only}}</td>
+	</tr>
+	<tr>
+		<td>Worklist</td>
+		<td>{{classifications.0.sample.worklist }}</td>
+	</tr>
+</table>
+
+
+
+
+
+<br>
+
+<form action="" method="post"> 
+
+{% csrf_token %}
+
+
+<input type="submit" value="Submit" class="btn btn-primary">
+
+<br>
+<br>
+
+<table id="classifications" class = "table table-hover table-bordered" style="width:100%">
+
+  <thead>
+	<tr>
+	  <th>Variant</th>
+	  <th>Analysis Performed</th>
+	  <th>Gene</th>
+	  <th>Genuine</th>
+	  <th>Previous Classification </th>
+	  <th>Status </th>
+	  <th>Genuine </th>
+
+
+	</tr>
+  </thead>
+
+  <tbody>
+  	{% for classification in classifications %}
+	<tr>
+		<td> <a href="http://localhost:60151/goto?locus={{classification.get_igv_locus}}">{{classification.variant|truncatechars:15}}</a></td>
+		<td> {{classification.sample.analysis_performed}} </td>
+		<td> {{classification.selected_transcript_variant.transcript.gene}} </td>
+
+
+
+		{% if classification.display_genuine != 'Genuine - New Classification' and classification.display_status == 'First Check' %}
+
+		<td> 
+			  <select name="{{classification.pk}}" id="{{classification.pk}}">
+			  <option value="None">None</option>
+			  <option value="Genuine - New Classification">Genuine - New Classification</option>
+			  <option value="Genuine - Use Previous Classification">Genuine - Use Previous Classification</option>
+			  <option value="Artefact">Artefact</option>
+			  </select> 
+
+        </td>
+
+        {% else %}
+        <td> {{classification.display_genuine}} </td>
+
+        {% endif %}
+
+
+
+		<td> {{classification.variant.most_recent_classification.0}} </td>
+		<td> {{classification.display_status}} </td>
+		<td> {{classification.display_genuine}} </td>
+
+
+	</tr>
+	{% endfor %}
+  </tbody>
+  </table>
+
+
+
+
+  
+</form>
+{% endblock %}

--- a/acmg_db/templates/acmg_db/artefact_check_select.html
+++ b/acmg_db/templates/acmg_db/artefact_check_select.html
@@ -1,0 +1,10 @@
+{% extends 'acmg_db/base.html' %}
+{% load static %}
+{% block content %}
+{% load crispy_forms_tags %}
+<br>
+
+{% crispy form %}
+
+
+{% endblock %}

--- a/acmg_db/templates/acmg_db/base.html
+++ b/acmg_db/templates/acmg_db/base.html
@@ -77,6 +77,11 @@
           <a class="nav-link" href="{% url 'download_variant_list' %}">Downloads<span class="sr-only">(current)</span></a>
         </li>
 
+        <li class="nav-item">
+          <a class="nav-link" href="{% url 'artefact_check_select' %}">Artefact Check<span class="sr-only">(current)</span></a>
+        </li>
+
+
 	<li class="nav-item">
           <a class="nav-link" href="{% url 'cnv_import' %}">CNV Analysis<span class="sr-only">(current)</span></a>
         </li>

--- a/acmg_db/templates/acmg_db/first_check.html
+++ b/acmg_db/templates/acmg_db/first_check.html
@@ -583,6 +583,15 @@
 					<td>{{ classification.user_creator }}</td>
 				</tr>
 				<tr>
+					<td>Artefact Checker</td>
+					<td>{{ classification.artefact_checker }}</td>
+				</tr>
+
+				<tr>
+					<td>Creation User</td>
+					<td>{{ classification.user_creator }}</td>
+				</tr>
+				<tr>
 					<td>First Check Date</td>
 					<td>{{ classification.first_check_date }}</td>
 				</tr>

--- a/acmg_db/templates/acmg_db/second_check.html
+++ b/acmg_db/templates/acmg_db/second_check.html
@@ -615,6 +615,10 @@
 					<td>{{ classification.user_creator }}</td>
 				</tr>
 				<tr>
+					<td>Artefact Check User</td>
+					<td>{{ classification.artefact_checker }}</td>
+				</tr>
+				<tr>
 					<td>First Check Date</td>
 					<td>{{ classification.first_check_date }}</td>
 				</tr>

--- a/acmg_db/templates/acmg_db/view_classification.html
+++ b/acmg_db/templates/acmg_db/view_classification.html
@@ -95,6 +95,22 @@
         <td> {{classification.user_creator }} </td>
       </tr>
       <tr>
+        <td> Artefact Check User</td>
+        <td> {{classification.artefact_checker }} </td>
+      </tr>
+      <tr>
+        <td> Artefact Check Date</td>
+        <td> {{classification.artefact_check_date }} </td>
+      </tr>
+
+
+
+
+
+
+
+
+      <tr>
         <td> First Check Date </td>
         <td> {{ classification.first_check_date|date:"d/m/Y"}} </td>
       </tr>
@@ -134,6 +150,11 @@
         <td> Analysis Performed </td>
         <td> {{classification.sample.analysis_performed|linebreaksbr }} </td>
       </tr>
+      <tr>
+        <td> VariantBank Analysis ID </td>
+        <td> {{classification.analysis_id }} </td>
+      </tr>
+
       <tr>
         <td> Other Changes </td>
         <td> {{classification.sample.other_changes|linebreaksbr }} </td>

--- a/acmg_db/urls.py
+++ b/acmg_db/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path('view_sample/<str:pk>/', views.view_sample, name='view_sample'),
 
     path('ajax/delete_comment/', views.ajax_delete_comment, name='ajax_delete_comment'),
+    path('artefact_check_select/', views.artefact_check_select, name='artefact_check_select'),
     path('artefact_check/<int:pk>', views.artefact_check, name='artefact_check'),
 
 

--- a/acmg_db/urls.py
+++ b/acmg_db/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path('view_sample/<str:pk>/', views.view_sample, name='view_sample'),
 
     path('ajax/delete_comment/', views.ajax_delete_comment, name='ajax_delete_comment'),
+    path('artefact_check/<int:pk>', views.artefact_check, name='artefact_check'),
 
 
     path('api-token-auth/', rest_views.obtain_auth_token),

--- a/acmg_db/views/generic_views.py
+++ b/acmg_db/views/generic_views.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.shortcuts import render, redirect, get_object_or_404
 from django.template.loader import render_to_string
 from django.http import HttpResponse
+from django.utils import timezone
 
 from acmg_db.models import *
 
@@ -100,3 +101,78 @@ def ajax_delete_comment(request):
 	else:
 
 			raise PermissionDenied('You do not have permission to delete this comment.')
+
+
+
+@transaction.atomic
+@login_required
+def artefact_check(request, pk):
+	"""
+	Allow arbitrary users to perform artefact checks
+	"""
+
+	classifications = Classification.objects.filter(analysis_id=pk)
+
+	if request.method == 'POST':
+
+		post_params = request.POST.dict()
+
+		del post_params['csrfmiddlewaretoken']
+
+		for key in post_params:
+
+			genuine_status = request.POST[key]
+
+			classification_obj = Classification.objects.get(pk=key)
+
+			previous_classifications = Classification.objects.filter(variant=classification_obj.variant,variant__genome=classification_obj.variant.genome, status__in=['2', '3']).exclude(pk=classification_obj.pk).order_by('-second_check_date')
+
+			# only update if no user assigned and first check
+			if classification_obj.status == '0' and classification_obj.user_first_checker is None:
+
+				if genuine_status == 'Artefact':
+
+					classification_obj.genuine = '4'
+					classification_obj.artefact_checker = request.user
+					classification_obj.artefact_check_date = timezone.now()
+					classification_obj.status = '1'
+					classification_obj.first_final_class = '6'
+					classification_obj.user_first_checker = request.user
+					classification_obj.first_check_date = timezone.now() 
+
+					classification_obj.save()
+
+				elif genuine_status == 'Genuine - New Classification':
+
+					classification_obj.genuine = '1'
+					classification_obj.artefact_checker = request.user
+					classification_obj.artefact_check_date = timezone.now()
+
+					# initiate classification 
+					classification_obj.initiate_classification()
+
+
+					classification_obj.save()
+
+
+				elif genuine_status == 'Genuine - Use Previous Classification':
+
+					# if there isnt a previous classification, throw a warning and stop
+					if len(previous_classifications) == 0:
+
+						print('No classification to use for previous')
+						# if there is, update final class to whatever it was previously
+					else:
+
+						classification_obj.genuine = '2'
+						classification_obj.artefact_checker = request.user
+						classification_obj.artefact_check_date = timezone.now()
+						classification_obj.status = '1'
+
+						classification_obj.first_final_class = previous_full_classifications[0].second_final_class
+
+						classification_obj.save()				
+				
+
+
+	return render(request, 'acmg_db/artefact_check.html', {'classifications':classifications})

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -14,7 +14,7 @@ import os
 
 # Is the instance of the database being run on a local development computer or on the cluster
 # options are 'local' or 'cluster'
-DB_INSTANCE = 'local'
+DB_INSTANCE = 'cluster'
 
 # path to file containing database password
 PASSWORD_FILE = '/export/home/webapps/password.txt'

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -14,7 +14,7 @@ import os
 
 # Is the instance of the database being run on a local development computer or on the cluster
 # options are 'local' or 'cluster'
-DB_INSTANCE = 'cluster'
+DB_INSTANCE = 'local'
 
 # path to file containing database password
 PASSWORD_FILE = '/export/home/webapps/password.txt'


### PR DESCRIPTION
Add capacity to do first checker artefact checks via a separate page.

User can go to artefact check page. Then they enter the analysis ID from the VariantBank. All classifications from that analysis will then be shown. Users can select whether the variant is genuine - new classification, genuine - use old classification or artefact. 

Users can only do this for variants on a status needing a first check and without a user already assigned