### PR TITLE
CNV Previous Classification Options

### DIFF
--- a/acmg_db/forms.py
+++ b/acmg_db/forms.py
@@ -431,6 +431,33 @@ class CNVGenuineArtefactForm(forms.Form):
 		self.helper.layout = Layout(
 			Field('genuine', id='genuine_field'),
 		)
+		
+class CNVPreviousClassificationsForm(forms.Form):
+	"""
+	Form to list all previous classifications as a drop down, allowing you to select which one you'd like to use for classification
+	"""
+	class_choices = CNV.FINAL_CLASS_CHOICES
+	previous_classification = forms.ChoiceField(choices=class_choices)
+	
+	def __init__(self, *args, **kwargs):
+	
+		self.cnv_pk = kwargs.pop('cnv_pk')
+		self.cnv = CNV.objects.get(pk = self.cnv_pk)
+		
+		super(CNVPreviousClassificationsForm, self).__init__(*args, **kwargs)
+
+		self.helper = FormHelper()
+		self.helper.form_id = 'genuine-artefact-form'
+		self.helper.label_class = 'col-lg-2'
+		self.helper.field_class = 'col-lg-8'
+		self.helper.form_method = 'post'
+		self.helper.form_action = reverse('cnv_first_check',kwargs={'pk':self.cnv_pk})
+		self.helper.add_input(Submit('submit', 'Update', css_class='btn-success'))
+		self.helper.form_class = 'form-horizontal'
+		self.helper.layout = Layout(
+			Field('previous_classification', id='previous_classifiction'),
+		)
+	
 
 
 class FinaliseClassificationForm(forms.Form):

--- a/acmg_db/templates/acmg_db/cnv_first_check.html
+++ b/acmg_db/templates/acmg_db/cnv_first_check.html
@@ -240,28 +240,31 @@
 		<p>An identical CNV, or a CNV which has at least 50% reciprocal overlap has been seen <b>{{ previous_classifications|length }} times</b> before. These CNVs may not be the same type (i.e. gain or loss) and may differ considerably in size, therefore these MUST be checked in detail.</p>
 		<table class="table">
 			<tr>
-				<td style="width: 20%"><b>Last seen:</b></td>
-				<td style="width: 20%">{{ previous_classifications.0.second_check_date|date:"d/m/Y"}}</td>
+			{% for classification in previous_classifications %}
+				<td style="width: 20%"><b>Date:</b></td>
+				<td style="width: 20%">{{ classification.second_check_date|date:"d/m/Y"}}</td>
 				<td style="width: 20%">
-					{% if 'Pathogenic' in previous_classifications.0.display_final_classification %}
+					{% if 'Pathogenic' in classification.display_final_classification %}
 					<button type="button" class="btn btn-danger btn-sm">
-					{% elif 'Benign' in previous_classifications.0.display_final_classification %}
+					{% elif 'Benign' in classification.display_final_classification %}
 					<button type="button" class="btn btn-info btn-sm">
-					{% elif 'VUS' in previous_classifications.0.display_final_classification %}
+					{% elif 'VUS' in classification.display_final_classification %}
 					<button type="button" class="btn btn-warning btn-sm">
-					{% elif 'Artefact' in previous_classifications.0.display_final_classification %}
+					{% elif 'Artefact' in classification.display_final_classification %}
 					<button type="button" class="btn btn-secondary btn-sm">
-					{% elif 'Contradictory' in previous_classifications.0.display_final_classification %}
+					{% elif 'Contradictory' in classification.display_final_classification %}
                     			<button type="button" class="btn btn-primary btn-sm">
 					{% else %}
 					<button type="button" class="btn btn-light btn-sm">
 					{% endif %}
-						{{ previous_classifications.0.display_final_classification }}
+						{{ classification.display_final_classification }}
 					</button>
 				</td>
-				<td style="width: 20%">{{ previous_classifications.0.guideline_version}}</td>
-				<td style="width: 20%"><a class="btn btn-light btn-sm" href="{% url 'cnv_view_classification' pk=previous_classifications.0.pk %}" role="button">View</a></td>
+				<td style="width: 20%">{{ classification.guideline_version}}</td>
+				<td style="width: 20%"><a class="btn btn-light btn-sm" href="{% url 'cnv_view_classification' pk=classification.pk %}" role="button">View</a></td>
 			</tr>
+			
+			{% endfor %}
 
 			{% if previous_full_classifications|length  > 0 %}
 			<tr>
@@ -315,6 +318,11 @@
 			This Classification has been set as {{ cnv.display_genuine }}. To change this you will need to reset the classification.
 			</div>
 
+		{% endif %}
+		
+		{% if prev_class_form != None %}
+		<br>Please select the previous classification you would like to use.</br>
+			{% crispy prev_class_form %}
 		{% endif %}
 		
 		<hr>

--- a/acmg_db/templates/acmg_db/cnv_second_check.html
+++ b/acmg_db/templates/acmg_db/cnv_second_check.html
@@ -271,28 +271,31 @@
 		<p>An identical CNV, or a CNV which has at least 50% reciprocal overlap has been seen <b>{{ previous_classifications|length }} times</b> before. These CNVs may not be the same type (i.e. gain or loss) and may differ considerably in size, therefore these MUST be checked in detail.</p>
 		<table class="table">
 			<tr>
-				<td style="width: 20%"><b>Last seen:</b></td>
-				<td style="width: 20%">{{ previous_classifications.0.second_check_date|date:"d/m/Y"}}</td>
+				{% for classification in previous_classifications %}
+					<td style="width: 20%"><b>Date:</b></td>
+				<td style="width: 20%">{{ classification.second_check_date|date:"d/m/Y"}}</td>
 				<td style="width: 20%">
-					{% if 'Pathogenic' in previous_classifications.0.display_final_classification %}
+					{% if 'Pathogenic' in classification.display_final_classification %}
 					<button type="button" class="btn btn-danger btn-sm">
-					{% elif 'Benign' in previous_classifications.0.display_final_classification %}
+					{% elif 'Benign' in classification.display_final_classification %}
 					<button type="button" class="btn btn-info btn-sm">
-					{% elif 'VUS' in previous_classifications.0.display_final_classification %}
+					{% elif 'VUS' in classification.display_final_classification %}
 					<button type="button" class="btn btn-warning btn-sm">
-					{% elif 'Artefact' in previous_classifications.0.display_final_classification %}
+					{% elif 'Artefact' in classification.display_final_classification %}
 					<button type="button" class="btn btn-secondary btn-sm">
-					{% elif 'Contradictory' in previous_classifications.0.display_final_classification %}
+					{% elif 'Contradictory' in classification.display_final_classification %}
                     			<button type="button" class="btn btn-primary btn-sm">
 					{% else %}
 					<button type="button" class="btn btn-light btn-sm">
 					{% endif %}
-						{{ previous_classifications.0.display_final_classification }}
+						{{ classification.display_final_classification }}
 					</button>
 				</td>
-				<td style="width: 20%">{{ previous_classifications.0.guideline_version}}</td>
-				<td style="width: 20%"><a class="btn btn-light btn-sm" href="{% url 'cnv_view_classification' pk=previous_classifications.0.pk %}" role="button">View</a></td>
+				<td style="width: 20%">{{ classification.guideline_version}}</td>
+				<td style="width: 20%"><a class="btn btn-light btn-sm" href="{% url 'cnv_view_classification' pk=classification.pk %}" role="button">View</a></td>
 			</tr>
+			
+			{% endfor %}
 
 			{% if previous_full_classifications|length  > 0 %}
 			<tr>

--- a/acmg_db/views/cnv_first_check_views.py
+++ b/acmg_db/views/cnv_first_check_views.py
@@ -312,7 +312,6 @@ def cnv_first_check(request, pk):
 				
 					if cnv.genuine  == '2' and cleaned_data['final_classification'] == '8':
 						#Get current classication
-						print(cnv.first_final_class)
 						if cnv.first_final_class not in class_options:
 							context['warn'] += ['You selected to use a previous classification, but the selected classification does not match any previous classifications for this CNV. Please contact bioinformatics to reset this CNV']
 					elif cnv.genuine == '2':

--- a/acmg_db/views/cnv_second_check_views.py
+++ b/acmg_db/views/cnv_second_check_views.py
@@ -250,9 +250,20 @@ def cnv_second_check(request, pk):
 						context['warn'] += ['Select whether the variant is genuine or artefact']
 
 
-					if cnv.genuine  == '2' and (cleaned_data['final_classification'] != previous_full_classifications[0].second_final_class):
+					#Now check all previous classifications and make sure that it's in this list
+					class_options = []
+					for entry in previous_full_classifications:
+						class_options.append(entry.second_final_class)
+						
+					if cnv.genuine  == '2' and (cleaned_data['final_classification'] not in class_options):
+						
+						context['warn'] += ['You selected to use a previous classification, but the selected classification does not match any previous classifications']
+					#Add check here that the decided previous classification matches between the checkers:	
+					elif cnv.genuine == '2':
+										
+						if cnv.first_final_class != cleaned_data['final_classification']:
+							context['warn'] += ['You selected to use a different previous classification than the first checker']
 
-						context['warn'] += ['You selected to use the last full classification, but the selected classification does not match']
 
 					if cnv.genuine  == '3' and cleaned_data['final_classification'] != '5':
 


### PR DESCRIPTION
For CNVs, now display all previous classifications and allow first checker to selected which they want to use by the following process:
- Select "Genuine - Use Previous Classification" and submit. 
- If more than one previous classification, a new drop down will appear with all classification options - select and submit. 

This is to fix the following issue - https://github.com/AWGL/variant_classification_DB/issues/71

Unit tests all running OK. 