### PR TITLE
Changing check for CNV answers to allow a buffer of 1 and a bug fix

### DIFF
--- a/acmg_db/models.py
+++ b/acmg_db/models.py
@@ -882,7 +882,11 @@ class CNV(models.Model):
 			all_questions_count = CNVGainClassificationQuestion.objects.all().count()
 
 			#Check we have all the answers
-			if len(classification_answers) != all_questions_count:
+			if len(classification_answers) == all_questions_count:
+				pass
+			elif len(classification_answers) == (all_questions_count - 1):
+				pass
+			else:
 				return 'NA'
 
 			final_score = 0
@@ -900,7 +904,11 @@ class CNV(models.Model):
 			all_questions_count = CNVLossClassificationQuestion.objects.all().count()
 
 			#Check we have all the answers
-			if len(classification_answers) != all_questions_count:
+			if len(classification_answers) == all_questions_count:
+				pass
+			elif len(classification_answers) == (all_questions_count - 1):
+				pass
+			else:
 				return 'NA'
 
 			final_score = 0
@@ -920,13 +928,17 @@ class CNV(models.Model):
 		FINAL_CLASS_CHOICES above
 		"""
 		
-		if self.gain_loss == 'Gain':
+		if self.method == 'Gain':
 			# pull out all classification questions and answers
 			classification_answers = CNVGainClassificationAnswer.objects.filter(cnv=self)
 			all_questions_count = CNVGainClassificationQuestion.objects.all().count()
 
 			#Check we have all the answers
-			if len(classification_answers) != all_questions_count:
+			if len(classification_answers) == all_questions_count:
+				pass
+			elif len(classification_answers) == (all_questions_count - 1):
+				pass
+			else:
 				return 'NA'
 
 			final_score = 0
@@ -937,14 +949,18 @@ class CNV(models.Model):
 
 			return final_score
 		
-		elif self.gain_loss == 'Loss':
-			
+		elif self.method == 'Loss':
+
 			# pull out all classification questions and answers
 			classification_answers = CNVLossClassificationAnswer.objects.filter(cnv=self)
 			all_questions_count = CNVLossClassificationQuestion.objects.all().count()
 
 			#Check we have all the answers
-			if len(classification_answers) != all_questions_count:
+			if len(classification_answers) == all_questions_count:
+				pass
+			elif len(classification_answers) == (all_questions_count - 1):
+				pass
+			else:
 				return 'NA'
 
 			final_score = 0
@@ -962,7 +978,11 @@ class CNV(models.Model):
 			all_questions_count = CNVLossClassificationQuestion.objects.all().count()
 
 			#Check we have all the answers
-			if len(classification_answers) != all_questions_count:
+			if len(classification_answers) == all_questions_count:
+				pass
+			elif len(classification_answers) == (all_questions_count - 1):
+				pass
+			else:
 				return 'NA'
 
 			final_score = 0

--- a/acmg_db/views/cnv_first_check_views.py
+++ b/acmg_db/views/cnv_first_check_views.py
@@ -379,8 +379,14 @@ def ajax_acmg_cnv_classification_first(request):
 			raise PermissionDenied('You do not have permission to start this classification.')
 		
 		if cnv.method == "Gain":
+		
+			#Check that correct number of questions present, have a buffer of 1 incase a new question gets added and some cases are half way
 			correct_number_of_questions = CNVGainClassificationQuestion.objects.all().count()
-			if len(classification_answers) != correct_number_of_questions:
+			if len(classification_answers) == correct_number_of_questions:
+				pass
+			elif len(classification_answers) == (correct_number_of_questions - 1):
+				pass
+			else:
 				raise Exception('Wrong number of questions')
 
 			# Update the classification answers
@@ -399,7 +405,12 @@ def ajax_acmg_cnv_classification_first(request):
 			
 		elif cnv.method == "Loss":
 			correct_number_of_questions = CNVLossClassificationQuestion.objects.all().count()
-			if len(classification_answers) != correct_number_of_questions:
+			
+			if len(classification_answers) == correct_number_of_questions:
+				pass
+			elif len(classification_answers) == (correct_number_of_questions - 1):
+				pass
+			else:
 				raise Exception('Wrong number of questions')
 			
 			# Update the classification answers

--- a/acmg_db/views/cnv_second_check_views.py
+++ b/acmg_db/views/cnv_second_check_views.py
@@ -41,7 +41,11 @@ def ajax_acmg_cnv_classification_second(request):
 		
 		if cnv.method == "Gain":
 			correct_number_of_questions = CNVGainClassificationQuestion.objects.all().count()
-			if len(classification_answers) != correct_number_of_questions:
+			if len(classification_answers) == correct_number_of_questions:
+				pass
+			elif len(classification_answers) == (correct_number_of_questions - 1):
+				pass
+			else:
 				raise Exception('Wrong number of questions')
 
 			# Update the classification answers
@@ -60,7 +64,11 @@ def ajax_acmg_cnv_classification_second(request):
 			
 		elif cnv.method == "Loss":
 			correct_number_of_questions = CNVLossClassificationQuestion.objects.all().count()
-			if len(classification_answers) != correct_number_of_questions:
+			if len(classification_answers) == correct_number_of_questions:
+				pass
+			elif len(classification_answers) == (correct_number_of_questions - 1):
+				pass
+			else:
 				raise Exception('Wrong number of questions')
 			
 			# Update the classification answers


### PR DESCRIPTION
Urgent fix to allow one less CNV answer than questions as a new criteria has been added, which has caused a bug for existing classifications. 

Whilst fixing, found small bug in models relating to second checking when the gain/loss classification method has been switched. 