### PR TITLE
Fix bug where incorrect genes are showing for previous classification

### DIFF
--- a/acmg_db/templates/acmg_db/cnv_first_check.html
+++ b/acmg_db/templates/acmg_db/cnv_first_check.html
@@ -254,7 +254,7 @@
 				<td style="width: 10%">{{ classification.second_check_date|date:"d/m/Y"}}</td>
 				<td style="width: 20%"> {{ classification.display }} </td>
 				<td style="width: 20%">
-				{% for gene in cnv.genes_as_list %}
+				{% for gene in classification.genes_as_list %}
 						<span class="badge badge-warning">{{ gene.gene }}</span>
 	  				{% endfor %}
 	  			</td>

--- a/acmg_db/templates/acmg_db/cnv_second_check.html
+++ b/acmg_db/templates/acmg_db/cnv_second_check.html
@@ -284,7 +284,7 @@
 				<td style="width: 10%">{{ classification.second_check_date|date:"d/m/Y"}}</td>
 				<td style="width: 20%"> {{ classification.display }} </td>
 				<td style="width: 20%">
-				{% for gene in cnv.genes_as_list %}
+				{% for gene in classification.genes_as_list %}
 						<span class="badge badge-warning">{{ gene.gene }}</span>
 	  				{% endfor %}
 	  			</td>


### PR DESCRIPTION
Incorrect genes showing for previous classifications on CNV DB as detailed in https://github.com/AWGL/variant_classification_DB/issues/85. It was showing the genes for the CNV being classified instead of the previously classified. 

Changed two templates to now show the correct genes. 

Unit tests all complete with no issue 