### PR TITLE
Remove previous media backup. Closes #91

### DIFF
--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -8,6 +8,9 @@ UPLOAD_DIR="/home/webapps/variant_classification_DB/mysite/media/uploads/"
 /usr/pgsql-9.6/bin/pg_dump variant_classification_db -U variant_classification_db_user -h localhost | gzip >  "$BACKUP_DIR"/"$(date '+%Y%m%d%H%M%S')_acmg_db.txt.gz"
 
 # Backup media uploads
+# First remove existing media backups so the backup size doesn't get out of control
+rm "$BACKUP_DIR"/media/*
+# Then make new backup
 cd "$UPLOAD_DIR"
 cd ..
 tar -czf "$BACKUP_DIR"/media/"$(date '+%Y%m%d%H%M%S')_media.tar.gz" uploads/


### PR DESCRIPTION
As per change in https://github.com/AWGL/variant_filtering_app/pull/178, remove existing media folder backups at each back up creation so only one at a time. 